### PR TITLE
WIP: ci: Make sure `tests-pass` is always run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,21 +17,24 @@ jobs:
   tests-pass:
     name: all systems go
     runs-on: ubuntu-latest
+    if: always()
+    env:
+      RESULT_CODE: ${{ success() && 0 || 1 }}    
     needs:
       - rustfmt
       - toml_validation
-      - clippy
-      - docs
-      - machete
-      - unused_dependencies
-      - test
-      - msrv
-      - minimal-versions
-      - kani
-      - no-std
+      # - clippy
+      # - docs
+      # - machete
+      # - unused_dependencies
+      # - test
+      # - msrv
+      # - minimal-versions
+      # - kani
+      # - no-std
       - check-readme
     steps:
-      - run: exit 0
+      - run: exit $RESULT_CODE
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -1283,6 +1283,8 @@ mod tests {
         let mut config = Config::new();
         config.protoc_executable("src/lib.rs");
 
+// This line needs to be formatted
+
         let err = config.load_fds(&[""], &[""]).unwrap_err();
         assert_starts_with!(err.to_string(), "failed to invoke protoc (hint: https://docs.rs/prost-build/#sourcing-protoc): (path: src/lib.rs): ")
     }


### PR DESCRIPTION
A GitHub action job is marked as success when it is skipped. The `needs` rule means that this job is skipped when one of the tests fails. Therefore, the required job `tests-pass` will never block a PR from merging.

> When a job fails, any jobs that depend on the failed job are skipped and do not report a failure. A pull request that requires the check may not be blocked. To use a required check on a job that depends on other jobs, use the `always()` conditional expression in addition to `needs`, see "Using jobs in a workflow."

Source: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks